### PR TITLE
Support a dynamic module with nginx 1.9.11+

### DIFF
--- a/config
+++ b/config
@@ -1,5 +1,14 @@
 USE_MD5=YES
 USE_SHA1=YES
 ngx_addon_name=ngx_http_upload_module
-HTTP_MODULES="$HTTP_MODULES ngx_http_upload_module"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_upload_module.c"
+
+if test -n "$ngx_module_link"; then
+    ngx_module_type=HTTP
+    ngx_module_name=$ngx_addon_name
+    ngx_module_srcs="$ngx_addon_dir/ngx_http_upload_module.c"
+
+    . auto/module
+else
+    HTTP_MODULES="$HTTP_MODULES ngx_http_upload_module"
+    NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_upload_module.c"
+fi


### PR DESCRIPTION
feature: this module can now be built as a "dynamic module" with NGINX 1.9.11+ via the --add-dynamic-module=PATH option of ./configure.
